### PR TITLE
feat(error): add ClientError mapping from tonic::Status

### DIFF
--- a/src/client/helper.rs
+++ b/src/client/helper.rs
@@ -359,7 +359,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
             {
                 Ok((rid, rdata))
             } else {
-                Err(ClientError::NotFound(format!("Not found runner: {runner_name}")).into())
+                Err(ClientError::NotFound(format!("runner not found: {runner_name}")).into())
             }
         }
     }
@@ -966,7 +966,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                 .find_runner_or_error(cx, metadata.clone(), &runner_name)
                 .await
                 .map_err(|_| {
-                    crate::error::ClientError::NotFound(format!("Not found runner: {runner_name}"))
+                    crate::error::ClientError::NotFound(format!("runner not found: {runner_name}"))
                 })?;
 
             let runner_settings_descriptor =
@@ -1127,7 +1127,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                 decode_output_to_json(&output_bytes, result_descriptor.as_ref())
             } else {
                 Err(ClientError::NotFound(format!(
-                    "Not found runner with id: {:?} for worker: {}",
+                    "runner not found with id: {:?} for worker: {}",
                     runner_id, &worker_data.name
                 ))
                 .into())
@@ -1196,7 +1196,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                 .await
                 .context("delete_worker_by_id")
             } else {
-                Err(ClientError::NotFound(format!("Not found worker to delete: {name}")).into())
+                Err(ClientError::NotFound(format!("worker not found: {name}")).into())
             }
         }
     }

--- a/src/client/helper.rs
+++ b/src/client/helper.rs
@@ -1,5 +1,6 @@
 use super::UseJobworkerpClient;
 use crate::command::to_request;
+use crate::error::ClientError;
 use crate::jobworkerp::data::{
     JobResultData, Priority, QueueType, ResponseType, ResultStatus, RetryPolicy, RetryType, Runner,
     RunnerData, RunnerId, Worker, WorkerData, WorkerId,
@@ -140,8 +141,12 @@ fn decode_output_to_json(
             Ok(m) => {
                 let j = ProtobufDescriptor::message_to_json(&m)?;
                 tracing::debug!("Result schema exists. decode message with proto: {:#?}", j);
-                serde_json::from_str(j.as_str())
-                    .map_err(|e| anyhow!("Failed to parse JSON from protobuf message: {e:#?}"))
+                serde_json::from_str(j.as_str()).map_err(|e| {
+                    ClientError::ParseError(format!(
+                        "Failed to parse JSON from protobuf message: {e:#?}"
+                    ))
+                    .into()
+                })
             }
             Err(e) => {
                 tracing::warn!(
@@ -149,7 +154,10 @@ fn decode_output_to_json(
                     e
                 );
                 serde_json::from_slice(output).map_err(|e_slice| {
-                    anyhow!("Failed to parse output as JSON (slice): {e_slice:#?}")
+                    ClientError::ParseError(format!(
+                        "Failed to parse output as JSON (slice): {e_slice:#?}"
+                    ))
+                    .into()
                 })
             }
         }
@@ -185,7 +193,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                         .await
                         .find_list(to_request(&metadata, request)?)
                         .await
-                        .map_err(|e| anyhow!(e))?;
+                        .map_err(ClientError::from_tonic_status)?;
                     let mut functions = Vec::new();
                     let mut stream = response.into_inner();
                     while let Some(t) = stream.next().await {
@@ -193,7 +201,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                             Ok(t) => {
                                 functions.push(t);
                             }
-                            Err(e) => return Err(anyhow!(e)),
+                            Err(e) => return Err(ClientError::from_tonic_status(e).into()),
                         }
                     }
                     Ok(functions)
@@ -224,7 +232,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                         .await
                         .find_list_by_set(to_request(&metadata, request)?)
                         .await
-                        .map_err(|e| anyhow!(e))?;
+                        .map_err(ClientError::from_tonic_status)?;
                     let mut functions = Vec::new();
                     let mut stream = response.into_inner();
                     while let Some(t) = stream.next().await {
@@ -232,7 +240,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                             Ok(t) => {
                                 functions.push(t);
                             }
-                            Err(e) => return Err(anyhow!(e)),
+                            Err(e) => return Err(ClientError::from_tonic_status(e).into()),
                         }
                     }
                     Ok(functions)
@@ -267,20 +275,9 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                     let res = runner_client
                         .find_by_name(to_request(&metadata, request)?)
                         .await
-                        .map_err(|e| anyhow!(e))?
+                        .map_err(ClientError::from_tonic_status)?
                         .into_inner();
                     Ok(res.data)
-                    // while let Some(item) = stream.next().await {
-                    //     match item {
-                    //         Ok(item) => {
-                    //             if item.data.as_ref().is_some_and(|d| d.name == name_owned) {
-                    //                 return Ok(Some(item));
-                    //             }
-                    //         }
-                    //         Err(e) => return Err(anyhow!(e)),
-                    //     }
-                    // }
-                    // Ok(None)
                 },
             )
             .await
@@ -310,7 +307,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                     let worker_response = worker_cli
                         .find_by_name(to_request(&metadata, request)?)
                         .await
-                        .map_err(|e| anyhow!(e))?;
+                        .map_err(ClientError::from_tonic_status)?;
 
                     let worker = worker_response.into_inner().data;
                     Ok(worker.and_then(|w| {
@@ -365,7 +362,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
             {
                 Ok((rid, rdata))
             } else {
-                Err(anyhow!("Not found runner: {runner_name}"))
+                Err(ClientError::NotFound(format!("Not found runner: {runner_name}")).into())
             }
         }
     }
@@ -400,7 +397,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                                 .find_by_name(to_request(&metadata_clone, req)?)
                                 .await
                                 .map(|response| response.into_inner().data)
-                                .map_err(|e| anyhow!(e))
+                                .map_err(|e| ClientError::from_tonic_status(e).into())
                         }
                     },
                 )
@@ -432,14 +429,17 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                                     .create(to_request(&metadata_clone, req)?)
                                     .await
                                     .map(|response| response.into_inner().id)
-                                    .map_err(|e| anyhow!(e))
+                                    .map_err(|e| ClientError::from_tonic_status(e).into())
                             }
                         },
                     )
                     .await;
 
-                let created_worker_id = created_worker_id_opt_res?
-                    .ok_or_else(|| anyhow!("create worker response is empty or id is None"))?;
+                let created_worker_id = created_worker_id_opt_res?.ok_or_else(|| {
+                    ClientError::RuntimeError(
+                        "create worker response is empty or id is None".to_string(),
+                    )
+                })?;
 
                 Ok(Worker {
                     id: Some(created_worker_id),
@@ -482,11 +482,12 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
             if res.status() == ResultStatus::Success {
                 Ok(res)
             } else {
-                Err(anyhow!(
+                Err(ClientError::RuntimeError(format!(
                     "job failed: {:?}",
                     res.output
                         .map(|o| String::from_utf8_lossy(&o.items).into_owned())
                 ))
+                .into())
             }
         }
     }
@@ -515,9 +516,9 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
             )
             .await?
             .result
-            .ok_or(anyhow!("result not found"))?
+            .ok_or_else(|| ClientError::NotFound("result not found".to_string()))?
             .data
-            .ok_or(anyhow!("result data not found"))
+            .ok_or_else(|| ClientError::NotFound("result data not found".to_string()).into())
         }
     }
     #[allow(clippy::too_many_arguments)]
@@ -549,16 +550,19 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                 let output = res
                     .output
                     .as_ref()
-                    .ok_or(anyhow!("job result output is empty: {res:?}"))?
+                    .ok_or_else(|| {
+                        ClientError::NotFound(format!("job result output is empty: {res:?}"))
+                    })?
                     .items
                     .to_owned();
                 Ok(output)
             } else {
-                Err(anyhow!(
+                Err(ClientError::RuntimeError(format!(
                     "job failed: {:?}",
                     res.output
                         .map(|o| String::from_utf8_lossy(&o.items).into_owned())
                 ))
+                .into())
             }
         }
     }
@@ -578,9 +582,11 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
             let worker = self
                 .find_or_create_worker(cx, metadata.clone(), worker_data)
                 .await?;
-            let worker_id = worker
-                .id
-                .ok_or(anyhow!("Worker ID not found after find_or_create_worker"))?;
+            let worker_id = worker.id.ok_or_else(|| {
+                ClientError::InvalidParameter(
+                    "Worker ID not found after find_or_create_worker".to_string(),
+                )
+            })?;
             let job_request_payload = build_job_request(
                 worker_id,
                 args,
@@ -605,7 +611,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                         .enqueue(to_request(&metadata, req)?)
                         .await
                         .map(|r| r.into_inner())
-                        .map_err(|e| anyhow!(e))
+                        .map_err(|e| ClientError::from_tonic_status(e).into())
                 },
             )
             .await
@@ -634,9 +640,11 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
             let worker = self
                 .find_or_create_worker(cx, metadata.clone(), worker_data)
                 .await?;
-            let worker_id = worker
-                .id
-                .ok_or(anyhow!("Worker ID not found after find_or_create_worker"))?;
+            let worker_id = worker.id.ok_or_else(|| {
+                ClientError::InvalidParameter(
+                    "Worker ID not found after find_or_create_worker".to_string(),
+                )
+            })?;
             let job_request_payload = build_job_request(
                 worker_id,
                 args,
@@ -661,7 +669,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                         .await
                         .enqueue_for_stream(to_request(&metadata_clone, req)?)
                         .await
-                        .map_err(|e| anyhow!(e))?;
+                        .map_err(ClientError::from_tonic_status)?;
                     let metadata_map = response.metadata().clone();
                     let streaming = response.into_inner();
                     Ok((metadata_map, streaming))
@@ -705,14 +713,14 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                         .await
                         .enqueue(to_request(&metadata, req)?)
                         .await
-                        .map_err(|e| anyhow!(e))?;
+                        .map_err(ClientError::from_tonic_status)?;
                     let job_response = response.into_inner();
-                    let job_result = job_response
-                        .result
-                        .ok_or_else(|| anyhow!("result not found in CreateJobResponse"))?;
-                    let job_result_data = job_result
-                        .data
-                        .ok_or_else(|| anyhow!("result data not found in JobResult"))?;
+                    let job_result = job_response.result.ok_or_else(|| {
+                        ClientError::NotFound("result not found in CreateJobResponse".to_string())
+                    })?;
+                    let job_result_data = job_result.data.ok_or_else(|| {
+                        ClientError::NotFound("result data not found in JobResult".to_string())
+                    })?;
                     Ok(job_result_data)
                 },
             )
@@ -723,7 +731,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
             if res.status() == ResultStatus::Success && res.output.is_some() {
                 let output_item = res
                     .output
-                    .ok_or(anyhow!("job result output is empty"))?
+                    .ok_or_else(|| ClientError::NotFound("job result output is empty".to_string()))?
                     .items
                     .to_owned();
                 Ok(output_item)
@@ -733,7 +741,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                     .as_ref()
                     .map(|e_bytes| String::from_utf8_lossy(&e_bytes.items).into_owned())
                     .unwrap_or_else(|| format!("job failed with status: {:?}", res.status()));
-                Err(anyhow!("job failed: {error_message}"))
+                Err(ClientError::RuntimeError(format!("job failed: {error_message}")).into())
             }
         }
     }
@@ -805,7 +813,12 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                     id: Some(wid),
                     data: Some(wdata),
                 } => (wid, wdata),
-                _ => return Err(anyhow!("Invalid worker: missing id or data")),
+                _ => {
+                    return Err(ClientError::InvalidParameter(
+                        "Invalid worker: missing id or data".to_string(),
+                    )
+                    .into());
+                }
             };
 
             let w = crate::jobworkerp::service::job_request::Worker::WorkerId(wid);
@@ -960,12 +973,16 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
 
             let runner_settings_descriptor =
                 JobworkerpProto::parse_runner_settings_schema_descriptor(&rdata).map_err(|e| {
-                    anyhow::anyhow!("Failed to parse runner_settings schema descriptor: {e:#?}")
+                    ClientError::ParseError(format!(
+                        "Failed to parse runner_settings schema descriptor: {e:#?}"
+                    ))
                 })?;
             let args_descriptor =
                 JobworkerpProto::parse_job_args_schema_descriptor(&rdata, using.as_deref())
                     .map_err(|e| {
-                        anyhow::anyhow!("Failed to parse job_args schema descriptor: {e:#?}")
+                        ClientError::ParseError(format!(
+                            "Failed to parse job_args schema descriptor: {e:#?}"
+                        ))
                     })?;
             let result_descriptor =
                 JobworkerpProto::parse_result_schema_descriptor(&rdata, using.as_deref())?;
@@ -976,7 +993,9 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                     .map(|j| JobworkerpProto::json_value_to_message(ope_desc, &j, true))
                     .unwrap_or(Ok(vec![]))
                     .map_err(|e| {
-                        anyhow::anyhow!("Failed to parse runner_settings schema: {e:#?}")
+                        ClientError::ParseError(format!(
+                            "Failed to parse runner_settings schema: {e:#?}"
+                        ))
                     })?
             } else {
                 tracing::debug!("runner settings schema empty");
@@ -985,9 +1004,13 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
             tracing::trace!("job args: {:#?}", &job_args);
             let job_args_bytes = match args_descriptor {
                 Some(desc) => JobworkerpProto::json_value_to_message(desc, &job_args, true)
-                    .map_err(|e| anyhow::anyhow!("Failed to parse job_args schema: {e:#?}"))?,
+                    .map_err(|e| {
+                        ClientError::ParseError(format!("Failed to parse job_args schema: {e:#?}"))
+                    })?,
                 _ => serde_json::to_string(&job_args)
-                    .map_err(|e| anyhow::anyhow!("Failed to serialize job_args: {e:#?}"))?
+                    .map_err(|e| {
+                        ClientError::ParseError(format!("Failed to serialize job_args: {e:#?}"))
+                    })?
                     .into_bytes(),
             };
 
@@ -1025,10 +1048,10 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
     ) -> impl std::future::Future<Output = Result<serde_json::Value>> + Send + 'a {
         async move {
             let runner_id = worker_data.runner_id.ok_or_else(|| {
-                anyhow!(
+                ClientError::InvalidParameter(format!(
                     "runner_id not found in worker_data for {}",
                     worker_data.name
-                )
+                ))
             })?;
 
             let client_clone = self.jobworkerp_client().clone();
@@ -1051,7 +1074,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                                 .find(to_request(&metadata_clone, req)?)
                                 .await
                                 .map(|response| response.into_inner().data)
-                                .map_err(|e| anyhow!(e))
+                                .map_err(|e| ClientError::from_tonic_status(e).into())
                         }
                     },
                 )
@@ -1067,14 +1090,24 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                 let args_descriptor = JobworkerpProto::parse_job_args_schema_descriptor(
                     &rdata, using,
                 )
-                .map_err(|e| anyhow!("Failed to parse job_args schema descriptor: {e:#?}"))?;
+                .map_err(|e| {
+                    ClientError::ParseError(format!(
+                        "Failed to parse job_args schema descriptor: {e:#?}"
+                    ))
+                })?;
 
                 tracing::trace!("job args (json): {:#?}", &job_args);
                 let job_args_bytes = match args_descriptor {
                     Some(desc) => JobworkerpProto::json_value_to_message(desc, &job_args, true)
-                        .map_err(|e| anyhow!("Failed to parse job_args schema: {e:#?}"))?,
+                        .map_err(|e| {
+                            ClientError::ParseError(format!(
+                                "Failed to parse job_args schema: {e:#?}"
+                            ))
+                        })?,
                     _ => serde_json::to_string(&job_args)
-                        .map_err(|e| anyhow!("Failed to serialize job_args: {e:#?}"))?
+                        .map_err(|e| {
+                            ClientError::ParseError(format!("Failed to serialize job_args: {e:#?}"))
+                        })?
                         .into_bytes(),
                 };
 
@@ -1095,11 +1128,11 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                     JobworkerpProto::parse_result_schema_descriptor(&rdata, using)?;
                 decode_output_to_json(&output_bytes, result_descriptor.as_ref())
             } else {
-                Err(anyhow!(
+                Err(ClientError::NotFound(format!(
                     "Not found runner with id: {:?} for worker: {}",
-                    runner_id,
-                    &worker_data.name
+                    runner_id, &worker_data.name
                 ))
+                .into())
             }
         }
     }
@@ -1134,7 +1167,7 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                                 .find_by_name(to_request(&metadata_clone, req)?)
                                 .await
                                 .map(|r| r.into_inner().data)
-                                .map_err(|e| anyhow!(e))
+                                .map_err(|e| ClientError::from_tonic_status(e).into())
                         }
                     },
                 )
@@ -1158,14 +1191,14 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                                 .delete(to_request(&metadata, req)?)
                                 .await
                                 .map(|r| r.into_inner().is_success)
-                                .map_err(|e| anyhow!(e))
+                                .map_err(|e| ClientError::from_tonic_status(e).into())
                         }
                     },
                 )
                 .await
                 .context("delete_worker_by_id")
             } else {
-                Err(anyhow!("Not found worker to delete: {name}"))
+                Err(ClientError::NotFound(format!("Not found worker to delete: {name}")).into())
             }
         }
     }

--- a/src/client/helper.rs
+++ b/src/client/helper.rs
@@ -11,7 +11,7 @@ use crate::jobworkerp::service::{
     CreateJobResponse, JobRequest, RunnerNameRequest, WorkerNameRequest,
 };
 use crate::proto::JobworkerpProto;
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use command_utils::cache_ok;
 use command_utils::protobuf::ProtobufDescriptor;
 use command_utils::trace::Tracing;
@@ -208,7 +208,6 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                 },
             )
             .await
-            .map_err(|e| anyhow!(e.to_string()))
         }
     }
     fn find_function_list_by_set<'a>(
@@ -247,7 +246,6 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                 },
             )
             .await
-            .map_err(|e| anyhow!(e.to_string()))
         }
     }
     fn find_runner_by_name<'a>(
@@ -281,7 +279,6 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
                 },
             )
             .await
-            .map_err(|e| anyhow!(e.to_string()))
         }
     }
     fn find_worker_by_name<'a>(
@@ -504,21 +501,22 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
         using: Option<&str>,
     ) -> impl std::future::Future<Output = Result<JobResultData>> + Send {
         async move {
-            self.enqueue_worker_job(
-                cx,
-                metadata,
-                worker_data,
-                args,
-                timeout_sec,
-                run_after_time,
-                priority,
-                using,
-            )
-            .await?
-            .result
-            .ok_or_else(|| ClientError::NotFound("result not found".to_string()))?
-            .data
-            .ok_or_else(|| ClientError::NotFound("result data not found".to_string()).into())
+            Ok(self
+                .enqueue_worker_job(
+                    cx,
+                    metadata,
+                    worker_data,
+                    args,
+                    timeout_sec,
+                    run_after_time,
+                    priority,
+                    using,
+                )
+                .await?
+                .result
+                .ok_or_else(|| ClientError::NotFound("result not found".to_string()))?
+                .data
+                .ok_or_else(|| ClientError::NotFound("result data not found".to_string()))?)
         }
     }
     #[allow(clippy::too_many_arguments)]

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -1,6 +1,7 @@
 use super::helper::UseJobworkerpClientHelper;
 use crate::{
     client::{JobworkerpClient, UseJobworkerpClient},
+    error::ClientError,
     jobworkerp::data::{Runner, RunnerType},
     proto::JobworkerpProto,
 };
@@ -122,11 +123,11 @@ impl JobworkerpClientWrapper {
                 tracing::debug!("No result schema: {}", text);
                 Ok(serde_json::Value::String(text.to_string()))
             }
-            .map_err(|e| anyhow::anyhow!("Failed to parse output: {e:#?}"));
+            .map_err(|e| ClientError::ParseError(format!("Failed to parse output: {e:#?}")).into());
             output
         } else {
             tracing::error!("runner not found: WORKFLOW");
-            Err(anyhow::anyhow!("runner not found: WORKFLOW"))
+            Err(ClientError::NotFound("runner not found: WORKFLOW".to_string()).into())
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,8 @@ pub enum ClientError {
     ExternalServiceError(String),
     #[error("RuntimeError({0})")]
     RuntimeError(String),
+    #[error("UnimplementedError({0})")]
+    UnimplementedError(String),
     #[error("UnknownError({0})")]
     UnknownError(String),
 }
@@ -35,10 +37,131 @@ impl ClientError {
             | tonic::Code::PermissionDenied
             | tonic::Code::Unavailable
             | tonic::Code::ResourceExhausted => ClientError::ExternalServiceError(message),
-            tonic::Code::FailedPrecondition | tonic::Code::Internal | tonic::Code::Cancelled => {
-                ClientError::RuntimeError(message)
-            }
+            tonic::Code::FailedPrecondition
+            | tonic::Code::Internal
+            | tonic::Code::Cancelled
+            | tonic::Code::DataLoss => ClientError::RuntimeError(message),
+            tonic::Code::Unimplemented => ClientError::UnimplementedError(message),
             _ => ClientError::UnknownError(message),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_tonic_status_not_found() {
+        let status = tonic::Status::not_found("resource not found");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::NotFound(msg) if msg == "resource not found"));
+    }
+
+    #[test]
+    fn test_from_tonic_status_invalid_argument() {
+        let status = tonic::Status::invalid_argument("bad input");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::InvalidParameter(msg) if msg == "bad input"));
+    }
+
+    #[test]
+    fn test_from_tonic_status_out_of_range() {
+        let status = tonic::Status::out_of_range("value out of range");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn test_from_tonic_status_already_exists() {
+        let status = tonic::Status::already_exists("resource exists");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::Conflict(_)));
+    }
+
+    #[test]
+    fn test_from_tonic_status_aborted() {
+        let status = tonic::Status::aborted("transaction aborted");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::Conflict(_)));
+    }
+
+    #[test]
+    fn test_from_tonic_status_deadline_exceeded() {
+        let status = tonic::Status::deadline_exceeded("timeout");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::TimeoutError(_)));
+    }
+
+    #[test]
+    fn test_from_tonic_status_unauthenticated() {
+        let status = tonic::Status::unauthenticated("not authenticated");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::ExternalServiceError(_)));
+    }
+
+    #[test]
+    fn test_from_tonic_status_permission_denied() {
+        let status = tonic::Status::permission_denied("access denied");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::ExternalServiceError(_)));
+    }
+
+    #[test]
+    fn test_from_tonic_status_unavailable() {
+        let status = tonic::Status::unavailable("service unavailable");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::ExternalServiceError(_)));
+    }
+
+    #[test]
+    fn test_from_tonic_status_resource_exhausted() {
+        let status = tonic::Status::resource_exhausted("rate limited");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::ExternalServiceError(_)));
+    }
+
+    #[test]
+    fn test_from_tonic_status_failed_precondition() {
+        let status = tonic::Status::failed_precondition("precondition failed");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::RuntimeError(_)));
+    }
+
+    #[test]
+    fn test_from_tonic_status_internal() {
+        let status = tonic::Status::internal("internal error");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::RuntimeError(_)));
+    }
+
+    #[test]
+    fn test_from_tonic_status_cancelled() {
+        let status = tonic::Status::cancelled("operation cancelled");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::RuntimeError(_)));
+    }
+
+    #[test]
+    fn test_from_tonic_status_data_loss() {
+        let status = tonic::Status::data_loss("data corrupted");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::RuntimeError(_)));
+    }
+
+    #[test]
+    fn test_from_tonic_status_unimplemented() {
+        let status = tonic::Status::unimplemented("method not implemented");
+        let error = ClientError::from_tonic_status(status);
+        assert!(
+            matches!(error, ClientError::UnimplementedError(msg) if msg == "method not implemented")
+        );
+    }
+
+    #[test]
+    fn test_from_tonic_status_unknown() {
+        let status = tonic::Status::unknown("unknown error");
+        let error = ClientError::from_tonic_status(status);
+        assert!(matches!(error, ClientError::UnknownError(_)));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,13 +26,16 @@ impl ClientError {
         let message = status.message().to_string();
         match status.code() {
             tonic::Code::NotFound => ClientError::NotFound(message),
-            tonic::Code::InvalidArgument => ClientError::InvalidParameter(message),
-            tonic::Code::AlreadyExists => ClientError::Conflict(message),
+            tonic::Code::InvalidArgument | tonic::Code::OutOfRange => {
+                ClientError::InvalidParameter(message)
+            }
+            tonic::Code::AlreadyExists | tonic::Code::Aborted => ClientError::Conflict(message),
             tonic::Code::DeadlineExceeded => ClientError::TimeoutError(message),
             tonic::Code::Unauthenticated
             | tonic::Code::PermissionDenied
-            | tonic::Code::Unavailable => ClientError::ExternalServiceError(message),
-            tonic::Code::FailedPrecondition | tonic::Code::Internal => {
+            | tonic::Code::Unavailable
+            | tonic::Code::ResourceExhausted => ClientError::ExternalServiceError(message),
+            tonic::Code::FailedPrecondition | tonic::Code::Internal | tonic::Code::Cancelled => {
                 ClientError::RuntimeError(message)
             }
             _ => ClientError::UnknownError(message),

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,3 +19,23 @@ pub enum ClientError {
     #[error("UnknownError({0})")]
     UnknownError(String),
 }
+
+impl ClientError {
+    /// Convert tonic::Status to ClientError based on gRPC status code
+    pub fn from_tonic_status(status: tonic::Status) -> Self {
+        let message = status.message().to_string();
+        match status.code() {
+            tonic::Code::NotFound => ClientError::NotFound(message),
+            tonic::Code::InvalidArgument => ClientError::InvalidParameter(message),
+            tonic::Code::AlreadyExists => ClientError::Conflict(message),
+            tonic::Code::DeadlineExceeded => ClientError::TimeoutError(message),
+            tonic::Code::Unauthenticated
+            | tonic::Code::PermissionDenied
+            | tonic::Code::Unavailable => ClientError::ExternalServiceError(message),
+            tonic::Code::FailedPrecondition | tonic::Code::Internal => {
+                ClientError::RuntimeError(message)
+            }
+            _ => ClientError::UnknownError(message),
+        }
+    }
+}


### PR DESCRIPTION
Map gRPC errors and domain-specific errors to appropriate ClientError variants to enable callers to handle errors by type via downcast_ref.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * クライアント側のエラーメッセージをさらに詳細かつ一貫性のある表現に改善しました。
  * gRPC応答のステータスをより正確にマッピングして、NotFound/InvalidParameter等の種別を明確に返すようになりました。
  * 解析失敗や空の応答などのケースで構造化されたエラーが返され、原因特定が容易になりました。

* **新機能**
  * 未実装扱いの状況を明示する新しいエラー種別を追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->