### PR TITLE
feat: add enqueue_stream_with_json and collect_stream_result to helpe…

### DIFF
--- a/src/client/helper.rs
+++ b/src/client/helper.rs
@@ -1470,7 +1470,11 @@ pub async fn collect_stream_result(
     } else {
         // When descriptor-based decoding failed (has_descriptor=false), the collected bytes
         // are concatenated raw chunks, not a valid single protobuf message.
-        let desc = if has_descriptor { result_descriptor } else { None };
+        let desc = if has_descriptor {
+            result_descriptor
+        } else {
+            None
+        };
         decode_output_to_json(&collected, desc)
     }
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -152,16 +152,21 @@ impl JobworkerpProto {
         descriptor: MessageDescriptor,
         json_value: &serde_json::Value,
         normalize_enum: bool,
-        _ignore_unknown_fields: bool,
+        ignore_unknown_fields: bool,
     ) -> Result<Vec<u8>> {
-        ProtobufDescriptor::json_value_to_message(descriptor, json_value, normalize_enum)
+        ProtobufDescriptor::json_value_to_message(
+            descriptor,
+            json_value,
+            normalize_enum,
+            ignore_unknown_fields,
+        )
     }
     pub fn json_to_message(
         descriptor: MessageDescriptor,
         json_str: &str,
-        _normalize_enum: bool,
+        normalize_enum: bool,
     ) -> Result<Vec<u8>> {
-        ProtobufDescriptor::json_to_message(descriptor, json_str)
+        ProtobufDescriptor::json_to_message(descriptor, json_str, normalize_enum)
     }
     pub fn parse_runner_settings_schema_descriptor(
         runner_data: &RunnerData,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -152,21 +152,16 @@ impl JobworkerpProto {
         descriptor: MessageDescriptor,
         json_value: &serde_json::Value,
         normalize_enum: bool,
-        ignore_unknown_fields: bool,
+        _ignore_unknown_fields: bool,
     ) -> Result<Vec<u8>> {
-        ProtobufDescriptor::json_value_to_message(
-            descriptor,
-            json_value,
-            normalize_enum,
-            ignore_unknown_fields,
-        )
+        ProtobufDescriptor::json_value_to_message(descriptor, json_value, normalize_enum)
     }
     pub fn json_to_message(
         descriptor: MessageDescriptor,
         json_str: &str,
-        normalize_enum: bool,
+        _normalize_enum: bool,
     ) -> Result<Vec<u8>> {
-        ProtobufDescriptor::json_to_message(descriptor, json_str, normalize_enum)
+        ProtobufDescriptor::json_to_message(descriptor, json_str)
     }
     pub fn parse_runner_settings_schema_descriptor(
         runner_data: &RunnerData,


### PR DESCRIPTION
…r trait

Enables cancellable LLM job execution by returning JobId from streaming enqueue. Also fixes proto.rs API compatibility with updated command-utils.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * JSON引数からのストリーミングジョブ登録と、ストリームからの逐次結果受信に対応しました。
  * ストリーミング出力をプロトコル定義（任意）でデコードしてJSONに変換・統合する機能を追加しました。
* **品質改善**
  * ストリーム分割された出力のマージ処理を改善し、文字列連結やスカラーは後勝ちで統合します。
  * ランナー不在や欠損ID等のエラー検出とログを強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->