### PR TITLE
Cli yaml

### DIFF
--- a/src/bin/command.rs
+++ b/src/bin/command.rs
@@ -33,7 +33,7 @@ use jobworkerp_client::{
     client::JobworkerpClient,
     command::{
         function::FunctionArg, function_set::FunctionSetArg, job::JobArg, job_result::JobResultArg,
-        job_status::JobStatusArg, runner::RunnerArg, worker::WorkerArg,
+        job_status::JobStatusArg, manifest::ManifestArg, runner::RunnerArg, worker::WorkerArg,
         worker_instance::WorkerInstanceArg,
     },
 };
@@ -60,6 +60,7 @@ pub(crate) enum SubCommand {
     JobResult(JobResultArg),
     JobStatus(JobStatusArg),
     WorkerInstance(WorkerInstanceArg),
+    Manifest(ManifestArg),
 }
 
 #[tokio::main]
@@ -112,6 +113,9 @@ async fn main() {
             cmd.cmd.execute(&client, &metadata).await;
         }
         SubCommand::WorkerInstance(cmd) => {
+            cmd.cmd.execute(&client, &metadata).await;
+        }
+        SubCommand::Manifest(cmd) => {
             cmd.cmd.execute(&client, &metadata).await;
         }
     }

--- a/src/client/helper.rs
+++ b/src/client/helper.rs
@@ -676,6 +676,21 @@ pub trait UseJobworkerpClientHelper: UseJobworkerpClient + Send + Sync + Tracing
     }
 
     /// Thin facade over
+    /// [`crate::client::worker_yaml::register_workers_from_yaml`].
+    /// Bound by `Self: Sized` for the same reason as [`Self::register_worker`].
+    fn register_workers_from_yaml<'a>(
+        &'a self,
+        cx: Option<&'a opentelemetry::Context>,
+        metadata: Arc<HashMap<String, String>>,
+        yaml_path: &'a std::path::Path,
+    ) -> impl std::future::Future<Output = Result<HashMap<String, WorkerId>>> + Send + 'a
+    where
+        Self: Sized,
+    {
+        crate::client::worker_yaml::register_workers_from_yaml(self, cx, metadata, yaml_path)
+    }
+
+    /// Thin facade over
     /// [`crate::client::function_set_yaml::register_function_sets_from_yaml`].
     /// Bound by `Self: Sized` for the same reason as [`Self::register_worker`].
     fn register_function_sets_from_yaml<'a>(

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -31,6 +31,12 @@ impl UseJobworkerpClient for JobworkerpClientWrapper {
 impl UseJobworkerpClientHelper for JobworkerpClientWrapper {}
 impl Tracing for JobworkerpClientWrapper {}
 
+impl From<JobworkerpClient> for JobworkerpClientWrapper {
+    fn from(jobworkerp_client: JobworkerpClient) -> Self {
+        Self { jobworkerp_client }
+    }
+}
+
 impl JobworkerpClientWrapper {
     const DEFAULT_REQUEST_TIMEOUT_SEC: u32 = 1200;
     pub async fn new(address: &str, request_timeout_sec: Option<u32>) -> Result<Self> {

--- a/src/command.rs
+++ b/src/command.rs
@@ -30,6 +30,7 @@ pub mod function_set;
 pub mod job;
 pub mod job_result;
 pub mod job_status;
+pub mod manifest;
 pub mod runner;
 pub mod worker;
 pub mod worker_instance;
@@ -90,4 +91,44 @@ pub fn to_request<T>(
         }
     }
     Ok(request)
+}
+
+/// Convert a `name → id` map (the return shape of every
+/// `register_*_from_yaml` helper) into JSON rows sorted by name. The
+/// `id_key` is the JSON field where the numeric id lands — callers use
+/// `"worker_id"` / `"function_set_id"` so downstream visualizers can show
+/// stable column headers.
+#[must_use]
+pub fn id_map_to_rows<I>(map: HashMap<String, I>, id_key: &str) -> Vec<serde_json::Value>
+where
+    I: IdValue,
+{
+    let mut rows: Vec<serde_json::Value> = map
+        .into_iter()
+        .map(|(name, id)| serde_json::json!({ "name": name, id_key: id.id_value() }))
+        .collect();
+    rows.sort_by(|a, b| {
+        a.get("name")
+            .and_then(serde_json::Value::as_str)
+            .cmp(&b.get("name").and_then(serde_json::Value::as_str))
+    });
+    rows
+}
+
+/// Extract the numeric value from a jobworkerp id newtype. Implemented for
+/// the small set of id types that the YAML `apply` commands return.
+pub trait IdValue {
+    fn id_value(&self) -> i64;
+}
+
+impl IdValue for crate::jobworkerp::data::WorkerId {
+    fn id_value(&self) -> i64 {
+        self.value
+    }
+}
+
+impl IdValue for crate::jobworkerp::function::data::FunctionSetId {
+    fn id_value(&self) -> i64 {
+        self.value
+    }
 }

--- a/src/command/function_set.rs
+++ b/src/command/function_set.rs
@@ -6,10 +6,12 @@
 // -c, --category <number> category of the function set (for create, update)
 // -t, --targets <json array string> targets of the function set (for create, update)
 
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use crate::{
-    command::to_request,
+    client::{helper::UseJobworkerpClientHelper, wrapper::JobworkerpClientWrapper},
+    command::{id_map_to_rows, to_request},
+    display::{DisplayOptions, utils::supports_color, visualize_rows},
     jobworkerp::{
         data::{RunnerId, WorkerId},
         function::{
@@ -82,6 +84,15 @@ pub enum FunctionSetCommand {
         id: i64,
     },
     Count {},
+    /// Apply function_set definitions from a YAML manifest file.
+    Apply {
+        /// Path to the function_set YAML file (see docs/function-set-yaml.md).
+        file: PathBuf,
+        #[clap(long, value_enum, default_value = "table")]
+        format: crate::display::DisplayFormat,
+        #[clap(long)]
+        no_truncate: bool,
+    },
 }
 
 #[allow(
@@ -305,8 +316,46 @@ impl FunctionSetCommand {
                     .unwrap();
                 println!("{response:#?}");
             }
+            Self::Apply {
+                file,
+                format,
+                no_truncate,
+            } => {
+                apply_function_sets(client, metadata, file, *format, *no_truncate).await;
+            }
         }
     }
+}
+
+async fn apply_function_sets(
+    client: &crate::client::JobworkerpClient,
+    metadata: &HashMap<String, String>,
+    file: &std::path::Path,
+    format: crate::display::DisplayFormat,
+    no_truncate: bool,
+) {
+    let wrapper: JobworkerpClientWrapper = client.clone().into();
+    let registered = match wrapper
+        .register_function_sets_from_yaml(None, Arc::new(metadata.clone()), file)
+        .await
+    {
+        Ok(map) => map,
+        Err(err) => {
+            eprintln!("function-set apply failed: {err:#}");
+            std::process::exit(1);
+        }
+    };
+
+    if registered.is_empty() {
+        println!("(no function_sets registered)");
+        return;
+    }
+
+    let rows = id_map_to_rows(registered, "function_set_id");
+    let options = DisplayOptions::new(format)
+        .with_color(supports_color())
+        .with_no_truncate(no_truncate);
+    println!("{}", visualize_rows(&rows, &options));
 }
 
 fn parse_targets(targets_json: &str) -> Vec<FunctionUsing> {
@@ -363,5 +412,65 @@ fn print_function_set(function_set: FunctionSet) {
         }
     } else {
         println!("Invalid function set data");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser, Debug)]
+    struct TestRoot {
+        #[clap(subcommand)]
+        cmd: FunctionSetCommand,
+    }
+
+    #[test]
+    fn parses_apply_with_format_and_no_truncate() {
+        let parsed = TestRoot::parse_from([
+            "test",
+            "apply",
+            "./fs.yaml",
+            "--format",
+            "json",
+            "--no-truncate",
+        ]);
+        match parsed.cmd {
+            FunctionSetCommand::Apply {
+                file,
+                format,
+                no_truncate,
+            } => {
+                assert_eq!(file, PathBuf::from("./fs.yaml"));
+                assert!(matches!(format, crate::display::DisplayFormat::Json));
+                assert!(no_truncate);
+            }
+            other => panic!("expected Apply, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_defaults_to_table_format() {
+        let parsed = TestRoot::parse_from(["test", "apply", "./fs.yaml"]);
+        match parsed.cmd {
+            FunctionSetCommand::Apply {
+                format,
+                no_truncate,
+                ..
+            } => {
+                assert!(matches!(format, crate::display::DisplayFormat::Table));
+                assert!(!no_truncate);
+            }
+            other => panic!("expected Apply, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_rejects_unknown_format() {
+        let err = TestRoot::try_parse_from(["test", "apply", "./fs.yaml", "--format", "xml"])
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("xml") || msg.contains("invalid value"));
     }
 }

--- a/src/command/manifest.rs
+++ b/src/command/manifest.rs
@@ -1,0 +1,157 @@
+// manifest: apply a combined worker + function_set YAML manifest.
+// See docs/manifest-yaml.md for the YAML schema.
+
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
+
+use crate::{
+    client::{
+        JobworkerpClient, helper::UseJobworkerpClientHelper, manifest_yaml::ManifestResult,
+        wrapper::JobworkerpClientWrapper,
+    },
+    command::id_map_to_rows,
+    display::{DisplayOptions, utils::supports_color, visualize_rows},
+};
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct ManifestArg {
+    #[clap(subcommand)]
+    pub cmd: ManifestCommand,
+}
+
+#[derive(Parser, Debug)]
+pub enum ManifestCommand {
+    /// Apply a manifest YAML file that combines workers and function_sets.
+    Apply {
+        /// Path to the manifest YAML file (see docs/manifest-yaml.md).
+        file: PathBuf,
+        #[clap(long, value_enum, default_value = "table")]
+        format: crate::display::DisplayFormat,
+        #[clap(long)]
+        no_truncate: bool,
+    },
+}
+
+impl ManifestCommand {
+    pub async fn execute(&self, client: &JobworkerpClient, metadata: &HashMap<String, String>) {
+        match self {
+            Self::Apply {
+                file,
+                format,
+                no_truncate,
+            } => {
+                apply_manifest(client, metadata, file, *format, *no_truncate).await;
+            }
+        }
+    }
+}
+
+async fn apply_manifest(
+    client: &JobworkerpClient,
+    metadata: &HashMap<String, String>,
+    file: &std::path::Path,
+    format: crate::display::DisplayFormat,
+    no_truncate: bool,
+) {
+    let wrapper: JobworkerpClientWrapper = client.clone().into();
+    let ManifestResult {
+        workers,
+        function_sets,
+    } = match wrapper
+        .register_manifest_from_yaml(None, Arc::new(metadata.clone()), file)
+        .await
+    {
+        Ok(r) => r,
+        Err(err) => {
+            eprintln!("manifest apply failed: {err:#}");
+            std::process::exit(1);
+        }
+    };
+
+    let worker_rows = id_map_to_rows(workers, "worker_id");
+    let fs_rows = id_map_to_rows(function_sets, "function_set_id");
+
+    if matches!(format, crate::display::DisplayFormat::Json) {
+        let combined = serde_json::json!({
+            "workers": worker_rows,
+            "function_sets": fs_rows,
+        });
+        let pretty =
+            serde_json::to_string_pretty(&combined).unwrap_or_else(|_| combined.to_string());
+        println!("{pretty}");
+        return;
+    }
+
+    let options = DisplayOptions::new(format)
+        .with_color(supports_color())
+        .with_no_truncate(no_truncate);
+    print_section("workers", &worker_rows, &options);
+    println!();
+    print_section("function_sets", &fs_rows, &options);
+}
+
+fn print_section(label: &str, rows: &[serde_json::Value], options: &DisplayOptions) {
+    println!("[{label}]");
+    if rows.is_empty() {
+        println!("(no {label} registered)");
+    } else {
+        println!("{}", visualize_rows(rows, options));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Parser, Debug)]
+    struct TestRoot {
+        #[clap(subcommand)]
+        cmd: ManifestCommand,
+    }
+
+    #[test]
+    fn parses_apply_with_format_and_no_truncate() {
+        let parsed = TestRoot::parse_from([
+            "test",
+            "apply",
+            "./manifest.yaml",
+            "--format",
+            "json",
+            "--no-truncate",
+        ]);
+        match parsed.cmd {
+            ManifestCommand::Apply {
+                file,
+                format,
+                no_truncate,
+            } => {
+                assert_eq!(file, PathBuf::from("./manifest.yaml"));
+                assert!(matches!(format, crate::display::DisplayFormat::Json));
+                assert!(no_truncate);
+            }
+        }
+    }
+
+    #[test]
+    fn apply_defaults_to_table_format() {
+        let parsed = TestRoot::parse_from(["test", "apply", "./manifest.yaml"]);
+        match parsed.cmd {
+            ManifestCommand::Apply {
+                format,
+                no_truncate,
+                ..
+            } => {
+                assert!(matches!(format, crate::display::DisplayFormat::Table));
+                assert!(!no_truncate);
+            }
+        }
+    }
+
+    #[test]
+    fn apply_rejects_unknown_format() {
+        let err = TestRoot::try_parse_from(["test", "apply", "./manifest.yaml", "--format", "xml"])
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("xml") || msg.contains("invalid value"));
+    }
+}

--- a/src/command/worker.rs
+++ b/src/command/worker.rs
@@ -13,11 +13,14 @@
 // --use-static <bool> use static worker (for create, update) (default: false)
 
 use crate::{
-    client::helper::DEFAULT_RETRY_POLICY,
-    command::to_request,
+    client::{
+        helper::DEFAULT_RETRY_POLICY, helper::UseJobworkerpClientHelper,
+        wrapper::JobworkerpClientWrapper,
+    },
+    command::{id_map_to_rows, to_request},
     display::{
         CardVisualizer, DisplayOptions, JsonPrettyVisualizer, JsonVisualizer, TableVisualizer,
-        utils::supports_color,
+        utils::supports_color, visualize_rows,
     },
     jobworkerp::{
         self,
@@ -29,7 +32,7 @@ use crate::{
 use anyhow::{Result, anyhow};
 use clap::{Parser, ValueEnum};
 // use command_utils::protobuf::ProtobufDescriptor;
-use std::{collections::HashMap, process::exit};
+use std::{collections::HashMap, path::PathBuf, process::exit, sync::Arc};
 
 pub mod display;
 use display::worker_to_json;
@@ -127,6 +130,15 @@ pub enum WorkerCommand {
         id: i64,
     },
     Count {},
+    /// Apply worker definitions from a YAML manifest file.
+    Apply {
+        /// Path to the worker YAML file (see docs/worker-yaml.md).
+        file: PathBuf,
+        #[clap(long, value_enum, default_value = "table")]
+        format: crate::display::DisplayFormat,
+        #[clap(long)]
+        no_truncate: bool,
+    },
 }
 
 #[derive(ValueEnum, Debug, Clone)]
@@ -456,6 +468,13 @@ impl WorkerCommand {
                     .unwrap();
                 println!("{response:#?}");
             }
+            Self::Apply {
+                file,
+                format,
+                no_truncate,
+            } => {
+                apply_workers(client, metadata, file, *format, *no_truncate).await;
+            }
         }
         async fn print_worker_formatted(
             client: &crate::client::JobworkerpClient,
@@ -558,5 +577,96 @@ impl WorkerCommand {
         //     }
         //     Ok(())
         // }
+    }
+}
+
+async fn apply_workers(
+    client: &crate::client::JobworkerpClient,
+    metadata: &HashMap<String, String>,
+    file: &std::path::Path,
+    format: crate::display::DisplayFormat,
+    no_truncate: bool,
+) {
+    let wrapper: JobworkerpClientWrapper = client.clone().into();
+    let registered = match wrapper
+        .register_workers_from_yaml(None, Arc::new(metadata.clone()), file)
+        .await
+    {
+        Ok(map) => map,
+        Err(err) => {
+            eprintln!("worker apply failed: {err:#}");
+            exit(1);
+        }
+    };
+
+    if registered.is_empty() {
+        println!("(no workers registered)");
+        return;
+    }
+
+    let rows = id_map_to_rows(registered, "worker_id");
+    let options = DisplayOptions::new(format)
+        .with_color(supports_color())
+        .with_no_truncate(no_truncate);
+    println!("{}", visualize_rows(&rows, &options));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser, Debug)]
+    struct TestRoot {
+        #[clap(subcommand)]
+        cmd: WorkerCommand,
+    }
+
+    #[test]
+    fn parses_apply_with_format_and_no_truncate() {
+        let parsed = TestRoot::parse_from([
+            "test",
+            "apply",
+            "./workers.yaml",
+            "--format",
+            "json",
+            "--no-truncate",
+        ]);
+        match parsed.cmd {
+            WorkerCommand::Apply {
+                file,
+                format,
+                no_truncate,
+            } => {
+                assert_eq!(file, PathBuf::from("./workers.yaml"));
+                assert!(matches!(format, crate::display::DisplayFormat::Json));
+                assert!(no_truncate);
+            }
+            other => panic!("expected Apply, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_defaults_to_table_format() {
+        let parsed = TestRoot::parse_from(["test", "apply", "./workers.yaml"]);
+        match parsed.cmd {
+            WorkerCommand::Apply {
+                format,
+                no_truncate,
+                ..
+            } => {
+                assert!(matches!(format, crate::display::DisplayFormat::Table));
+                assert!(!no_truncate);
+            }
+            other => panic!("expected Apply, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_rejects_unknown_format() {
+        let err = TestRoot::try_parse_from(["test", "apply", "./workers.yaml", "--format", "xml"])
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("xml") || msg.contains("invalid value"));
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -12,7 +12,9 @@ pub mod visualizer;
 // Re-exports for public API
 pub use format::DisplayFormat;
 pub use utils::{format_json_hierarchy, truncate_string};
-pub use visualizer::{CardVisualizer, JsonPrettyVisualizer, JsonVisualizer, TableVisualizer};
+pub use visualizer::{
+    CardVisualizer, JsonPrettyVisualizer, JsonVisualizer, TableVisualizer, visualize_rows,
+};
 
 /// Display configuration options
 #[derive(Debug, Clone)]

--- a/src/display/visualizer.rs
+++ b/src/display/visualizer.rs
@@ -156,6 +156,18 @@ impl JsonVisualizer for CardVisualizer {
 /// Pretty JSON format visualizer
 pub struct JsonPrettyVisualizer;
 
+/// Dispatch to the visualizer matching `options.format`. Centralises the
+/// `match format { Table => …, Card => …, Json => … }` block that the
+/// per-command modules would otherwise repeat for every list-style output.
+#[must_use]
+pub fn visualize_rows(data: &[JsonValue], options: &DisplayOptions) -> String {
+    match options.format {
+        crate::display::DisplayFormat::Table => TableVisualizer.visualize(data, options),
+        crate::display::DisplayFormat::Card => CardVisualizer.visualize(data, options),
+        crate::display::DisplayFormat::Json => JsonPrettyVisualizer.visualize(data, options),
+    }
+}
+
 /// Streaming table format visualizer (displays each item as individual table)
 pub struct StreamingTableVisualizer;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * マニフェストコマンドに `apply` サブコマンドを追加。YAMLファイルからワーカーと関数セットを一括で登録できるようになりました
  * ワーカーおよび関数セットコマンドに `apply` サブコマンドを追加し、YAMLファイルからの一括登録に対応しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->